### PR TITLE
LayoutDefault.astro: fix typography

### DIFF
--- a/src/layouts/LayoutDefault.astro
+++ b/src/layouts/LayoutDefault.astro
@@ -25,10 +25,10 @@ import './../style.css';
       <div class="flex flex-col items-center justify-center text-center mt-10  pb-8">
         <img src="/logo.svg" alt="NixCon 2023" class="w-56 md:w-72" />
         <p class="mt-4 text-3xl md:text-5xl font-bold text-gray-600 font-behrensschrift">
-          Darmstadt 2023
+          Darmſtadt 2023
         </p>
         <p class="text-3xl font-behrensschrift font-bold text-gray-600">
-          September 08 - 10
+          September 08 – 10
         </p>
       </div>
       <slot />


### PR DESCRIPTION
When using historic fonts, one also should use appropriate orthography, in this case a German word requires the use of a long s.

Also use an en-dash for the date range.