### PR TITLE
the image is placed in a absolute manner

### DIFF
--- a/src/layouts/LayoutText.astro
+++ b/src/layouts/LayoutText.astro
@@ -10,7 +10,7 @@ import LayoutDefault from "./LayoutDefault.astro";
       <slot />
     </article>
   </div>
-  <img src="./separator.svg"
+  <img src="/separator.svg"
     aria-hidden="true"
     class="w-full md:max-w-[50em] mx-auto mt-4 mb-8"
   />


### PR DESCRIPTION
Subpages (like https://2023.nixcon.org/code-of-conduct/) do not show the image because the relative path (reference) does not point to the absolute location.