### PR TITLE
hotfix(2am): ticket_data.results can be empty…

### DIFF
--- a/src/components/TicketView.astro
+++ b/src/components/TicketView.astro
@@ -23,7 +23,7 @@ if (!process.env["NIX_BUILD_TOP"]) {
 
 <div class="flex flex-col justify-center gap-4 pt-1">
   {
-    ticket_data.results
+    (ticket_data.results || [])
       .sort((a, b) => a.position - b.position)
       .filter((ticket) => ticket.active)
       .map((ticket) => (


### PR DESCRIPTION
Yeah, it is enough to have ticket_data == {} or similar to have undefined results.