### PR TITLE
Out of tickets

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,10 +66,23 @@ import Sponsor from "../components/Sponsor.astro";
   <Section extraClasses="pb-4">
     <SectionHeading>Tickets</SectionHeading>
     <SectionParagraph>
-      Ticket sales will start immediately at <a
-        href="https://tickets.nixcon.org/2023/"
-        rel="external">https://tickets.nixcon.org/2023/</a
-      >. If you are unable to afford a ticket, please contact us at
+      Tickets are all taken!<br />
+      Live streaming will be available. Follow one of the NixOS social accounts for updates:
+      <ul class="linklist">
+        <li>
+          <a href="https://chaos.social/@nixos_org" rel="external"
+              >@nixos_org@chaos.social</a
+          >
+        </li>
+        <li>
+          <a href="https://twitter.com/nixos_org" rel="external"
+            >@nixos_org</a
+          >
+        </li>
+      </ul>
+    </SectionParagraph>
+    <SectionParagraph>
+      Speakers without tickets, please reach out to us at
       <a href="mailto:orgateam@nixcon.org">orgateam@nixcon.org</a>.
     </SectionParagraph>
     <TicketView />


### PR DESCRIPTION
Change the ticket paragraph to reflect they are sold out.

Note live-streaming as an alternative, and link to the NixOS social accounts.

Add a note for speakers without tickets to get in touch.

Removed mention of ticket transfer and the waitlist as it is too long.