### PR TITLE
Make the logo clickable

### DIFF
--- a/src/layouts/LayoutDefault.astro
+++ b/src/layouts/LayoutDefault.astro
@@ -25,12 +25,14 @@ import "./../style.css";
       <div
         class="flex flex-col items-center justify-center text-center mt-10 pb-8"
       >
-        <img src="/logo.svg" alt="NixCon 2023" class="w-56 md:w-72" />
-        <p
-          class="mt-4 text-3xl md:text-5xl font-bold text-gray-600 font-behrensschrift"
-        >
-          Darmſtadt 2023
-        </p>
+        <a href="/">
+	    <img src="/logo.svg" alt="NixCon 2023" class="w-56 md:w-72" />
+	    <p
+	    class="mt-4 text-3xl md:text-5xl font-bold text-gray-600 font-behrensschrift"
+	    >
+	    Darmſtadt 2023
+	    </p>
+	</a>
         <p class="text-3xl font-behrensschrift font-bold text-gray-600">
           September 08 – 10
         </p>


### PR DESCRIPTION
This allows visitors to go back to the start page by clicking on the logo (as is often the case on many pages). Especially with the CoC and the Talks page there wasn't a way to navigate back except for your browsers facilities.